### PR TITLE
Close, minimize and full screen buttons for the calculator app.

### DIFF
--- a/javascript/script.js
+++ b/javascript/script.js
@@ -227,6 +227,10 @@ terminalApp.full.addEventListener("click", () =>
 notesApp.full.addEventListener("click", () =>
   handleFullScreen(notesApp.window)
 );
+/* Added the function to handle the full screen buttons for the calculator app; */
+calculatorAppApp.full.addEventListener("click", () =>
+  handleFullScreen(calculatorAppApp.window)
+);
 /*
 vscodeApp.full.addEventListener("click", () =>
   handleFullScreen(vscodeApp.window)


### PR DESCRIPTION
Good afternoon,

This project is an amazing idea, if I had this idea I would work on it for ever. Anyway, I have added an event listener so that once the minimize and full screen buttons on the calculator app is clicked the calculator follows the function which is to make it bigger and smaller. I don't know if you would like that but I believe that it is a good idea to make the calculator app to have the same full screen, minimize and close options as the other apps.

Good luck!!